### PR TITLE
Prevent ArrayIndexOutOfBoundsException in TaskList with index checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ find book
 bye
 
 
-## FAQs
+## FAQs :question:
 
 **Q: How do I ensure my tasks are saved?**  
 A: Cleo automatically saves your tasks in a file. Your tasks will be loaded the next time you start the app.


### PR DESCRIPTION
Validate indices in TaskList's getTask, removeTask, etc. to ensure they are within the valid 0 to (size - 1) range. Assertions added for a more robust TaskList in development and testing.

